### PR TITLE
Made tests run, properly handle the case where a template is not found.

### DIFF
--- a/overextends/templatetags/overextends_tags.py
+++ b/overextends/templatetags/overextends_tags.py
@@ -90,6 +90,8 @@ class OverExtendsNode(ExtendsNode):
         # is requested.
         for loader in loaders:
             dirs = context[context_name][name]
+            if not dirs:
+                break
             try:
                 source, path = loader.load_template_source(name, dirs)
             except TemplateDoesNotExist:

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -6,7 +6,13 @@ PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
 PROJECT_DIRNAME = PROJECT_ROOT.split(os.sep)[-1]
 ROOT_URLCONF = "%s.urls" % PROJECT_DIRNAME
 TEMPLATE_DIRS = (os.path.join(PROJECT_ROOT, "templates"),)
-TEST_RUNNER = "django.test.simple.DjangoTestSuiteRunner"
+
+try:
+    import django.test.runner
+    TEST_RUNNER = "django.test.runner.DiscoverRunner"
+except ImportError as e:
+    TEST_RUNNER = "django.test.simple.DjangoTestSuiteRunner"
+
 SECRET_KEY = "hi mom"
 
 DATABASES = {


### PR DESCRIPTION
The tests wouldn’t run on Django 1.8 because `django.test.simple.DjangoTestSuiteRunner` no longer exists. Also, if `dirs` is empty, it means we cannot find the template; we mustn’t pass an empty `dirs` argument to `load_template_source` because the latter will interpret that as an instruction to search everywhere for the template, so we’ll get a circularity.