### PR TITLE
Django 1.8 settings

### DIFF
--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -23,27 +23,33 @@ DATABASES = {
     }
 }
 
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
-TEMPLATE_DIRS = (os.path.join(PROJECT_ROOT, "templates"),)
+BASE_TEMPLATE_DIRS = (os.path.join(PROJECT_ROOT, "templates"),)
 
-TEMPLATE_OPTIONS = {}
-if django.VERSION >= (1, 9):
-    # only set builtins option on Django >= 1.9
-    TEMPLATE_OPTIONS = {
-        'builtins': ['overextends.templatetags.overextends_tags'],
-    }
+if django.VERSION >= (1, 8):
+    # Only set TEMPLATES for Django >= 1.8
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'DIRS': TEMPLATE_DIRS,
-        'OPTIONS': TEMPLATE_OPTIONS
-    },
-]
+    TEMPLATE_OPTIONS = {}
+    if django.VERSION >= (1, 9):
+        # only set builtins option on Django >= 1.9
+        TEMPLATE_OPTIONS = {
+            'builtins': ['overextends.templatetags.overextends_tags'],
+        }
+
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'DIRS': BASE_TEMPLATE_DIRS,
+            'OPTIONS': TEMPLATE_OPTIONS
+        },
+    ]
+else:
+    TEMPLATE_LOADERS = (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )
+    TEMPLATE_DIRS = BASE_TEMPLATE_DIRS
+
 
 INSTALLED_APPS = (
     'overextends',


### PR DESCRIPTION
Currently overextends fails with Django 1.8+ unless you've got `TEMPLATE_DIRS` and `TEMPLATE_LOADERS` in settings - even though they're not needed with the new `TEMPLATES` dict.

These commits should limit the test project settings file to the appropriate settings for each version of Django, and for 1.8+ it looks at the dirs/loaders for the current engine instead of the old settings.