### PR TITLE
Add Django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ matrix:
     - python: "3.3"
       env: "DJANGO_VERSION=1.10"
 install:
-  - pip install django==$DJANGO_VERSION --use-mirrors
-  - pip install . --use-mirrors
+  - pip install django==$DJANGO_VERSION
+  - pip install .
 script: ./test_project/manage.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
   - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
+  - DJANGO_VERSION=1.10
 python:
   - "2.7"
   - "3.3"
@@ -14,6 +15,8 @@ matrix:
       env: "DJANGO_VERSION=1.7"
     - python: "3.3"
       env: "DJANGO_VERSION=1.9"
+    - python: "3.3"
+      env: "DJANGO_VERSION=1.10"
 install:
   - pip install django==$DJANGO_VERSION --use-mirrors
   - pip install . --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-  - DJANGO_VERSION=1.7
   - DJANGO_VERSION=1.8
   - DJANGO_VERSION=1.9
   - DJANGO_VERSION=1.10
@@ -11,8 +10,6 @@ python:
   - "3.5"
 matrix:
   exclude:
-    - python: "3.5"
-      env: "DJANGO_VERSION=1.7"
     - python: "3.3"
       env: "DJANGO_VERSION=1.9"
     - python: "3.3"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages = find_packages(),
     install_requires = [
         "sphinx-me >= 0.1.2",
-        "django >= 1.7, < 1.10",
+        "django >= 1.7, < 1.11",
     ],
     classifiers = [
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     packages = find_packages(),
     install_requires = [
         "sphinx-me >= 0.1.2",
-        "django >= 1.7, < 1.11",
+        "django >= 1.8, < 1.11",
     ],
     classifiers = [
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This just opens up installation and testing for 1.10.  No tests fail so I assume it's usable.  I drop Django 1.7 testing, there is one site in the code that has a `<= 1.7` fallback that I didn't remove.