### PR TITLE
Travis: use latest release in Django series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 env:
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
-  - DJANGO_VERSION=1.10
+  - DJANGO_VERSION=1.8.0
+  - DJANGO_VERSION=1.9.0
+  - DJANGO_VERSION=1.10.0
 python:
   - "2.7"
   - "3.3"
@@ -11,10 +11,10 @@ python:
 matrix:
   exclude:
     - python: "3.3"
-      env: "DJANGO_VERSION=1.9"
+      env: "DJANGO_VERSION=1.9.0"
     - python: "3.3"
-      env: "DJANGO_VERSION=1.10"
+      env: "DJANGO_VERSION=1.10.0"
 install:
-  - pip install django==$DJANGO_VERSION
+  - pip install django~=$DJANGO_VERSION
   - pip install .
 script: ./test_project/manage.py test


### PR DESCRIPTION
The way Travis was setup we were always testing against the initial .0 release in the series.  Now we're testing against the current latest release in a series.