### PR TITLE
sphinx-me is only required by developers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,9 +15,13 @@ setup(
     include_package_data = True,
     packages = find_packages(),
     install_requires = [
-        "sphinx-me >= 0.1.2",
         "django >= 1.8, < 1.11",
     ],
+    extras_require = {
+        'dev': [
+            "sphinx-me >= 0.1.2",
+        ]
+    },
     classifiers = [
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",


### PR DESCRIPTION
Create a 'dev' target to install development requirements:
  `pip install django-overextends[dev]`

This is a breakout of https://github.com/stephenmcd/django-overextends/pull/28/commits/920d7a5c80c4d32ae63dd6438c8ac658e49a77bb